### PR TITLE
Replace subdoc with embed, cleanup readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 A plug-n-play Typescript interface generator for Mongoose.
 
-[![oclif](https://img.shields.io/badge/cli-oclif-brightgreen.svg)](https://oclif.io)
 [![Version](https://img.shields.io/npm/v/mongoose-tsgen.svg)](https://npmjs.org/package/mongoose-tsgen)
 [![npm](https://img.shields.io/npm/dt/mongoose-tsgen)](https://www.npmjs.com/package/mongoose-tsgen)
 [![License](https://img.shields.io/npm/l/mongoose-tsgen.svg)](https://github.com/Bounced-Inc/mongoose-tsgen/blob/master/package.json)
@@ -33,7 +32,6 @@ A plug-n-play Typescript interface generator for Mongoose.
 - [x] Typescript path aliases
 - [x] Mongoose method, static & query functions
 - [x] Typesafe document creation with `Model.Create`
-- [ ] Setting subdocument arrays without casting to `any` (currently you need to do `user.friends = [{ uid, name }] as any` or you can initialize the subdocument prior to setting it)
 
 # Installation
 
@@ -233,7 +231,7 @@ export interface User {
   _id: mongoose.Types.ObjectId;
 }
 
-export type UserFriendDocument = mongoose.Types.Subdocument & {
+export type UserFriendDocument = mongoose.Types.Embedded & {
   uid: UserDocument["_id"] | UserDocument;
 } & UserFriend;
 

--- a/src/helpers/parser.ts
+++ b/src/helpers/parser.ts
@@ -132,9 +132,10 @@ export const parseSchema = ({
         childInterfaces += parseSchema({
           schema: child.schema,
           modelName: name,
+          // we use "mongoose.Types.Embedded" instead of "mongoose.Types.Subdocument" to give us access to additional subdoc functions such as doc.parent()
           header: isDocument ?
             `type ${name}Document = ${
-                isSubdocArray ? "mongoose.Types.Subdocument" : `mongoose.Document & ${name}Methods`
+                isSubdocArray ? "mongoose.Types.Embedded" : `mongoose.Document & ${name}Methods`
               } & {\n` :
             `interface ${name} {`,
           isDocument,

--- a/src/helpers/tests/artifacts/example.index.d.ts
+++ b/src/helpers/tests/artifacts/example.index.d.ts
@@ -40,7 +40,7 @@ coordinates?: number[];
 _id: mongoose.Types.ObjectId;
 }
 
-type UserFriendDocument = mongoose.Types.Subdocument & {
+type UserFriendDocument = mongoose.Types.Embedded & {
 uid: UserDocument["_id"] | UserDocument;
 } & UserFriend
 

--- a/src/helpers/tests/artifacts/mongoose.gen.ts
+++ b/src/helpers/tests/artifacts/mongoose.gen.ts
@@ -38,7 +38,7 @@ coordinates?: number[];
 _id: mongoose.Types.ObjectId;
 }
 
-export type UserFriendDocument = mongoose.Types.Subdocument & {
+export type UserFriendDocument = mongoose.Types.Embedded & {
 uid: UserDocument["_id"] | UserDocument;
 } & UserFriend
 


### PR DESCRIPTION
See the first comment on https://stackoverflow.com/a/63832238/8292279, using `mongoose.Types.Embedded` over `mongoose.Types.Subdocument` gives ability to use `doc.parent()` and other subdoc functions.