### PR TITLE
Subdocument Array type problem

### DIFF
--- a/src/helpers/parser.ts
+++ b/src/helpers/parser.ts
@@ -133,10 +133,10 @@ export const parseSchema = ({
         childInterfaces += parseSchema({
           schema: child.schema,
           modelName: name,
-          // we use "mongoose.Types.Embedded" instead of "mongoose.Types.Subdocument" to give us access to additional subdoc functions such as doc.parent()
+          // we use "mongoose.Types.EmbeddedDocument" instead of "mongoose.Types.Subdocument" to give us access to additional subdoc functions such as doc.parent()
           header: isDocument ?
             `type ${name}Document = ${
-                isSubdocArray ? "mongoose.Types.Embedded" : `mongoose.Document & ${name}Methods`
+                isSubdocArray ? "mongoose.Types.EmbeddedDocument" : `mongoose.Document & ${name}Methods`
               } & {\n` :
             `interface ${name} {`,
           isDocument,


### PR DESCRIPTION
Using "EmbeddedDocument" instead of "Embedded" in case of an array of Sub-document fixes a type issue.

More explanation:

Hey there. I'm a newbie, I might be wrong, or there is a better fix maybe.

I'll try my best to explain.

In a Schema, where I use an Array of Sub-documents, like 
```
const UserSchema = new Schema(
	{
                //Other properties
		passwordReset: [
			{
				code: {
					type: String,
				},
				time: {
					type: Date,
				},
			},
		],
	}
);
```

And in the generated interface:
`export type UserPasswordResetDocument = mongoose.Types.Embedded & {} & UserPasswordReset;`
this line creates a problem like so: _Type 'UserPasswordResetDocument' does not satisfy the constraint 'Document<any>'._

Once I replaced mongoose.Types.Embedded with mongoose.Types.EmbeddedDocument, the error got fixed.