### PR TITLE
Enhance support for Object and Array types

### DIFF
--- a/src/helpers/parser.ts
+++ b/src/helpers/parser.ts
@@ -290,7 +290,13 @@ const convertBaseTypeToTs = (key: string, val: any, isDocument: boolean) => {
   let valType: string | undefined;
   // NOTE: ideally we check actual type of value to ensure its Schema.Types.Mixed (the same way we do with Schema.Types.ObjectId),
   // but this doesnt seem to work for some reason
-  if (val.schemaName === "Mixed" || val.type?.schemaName === "Mixed") {
+  // {} is treated as Mixed
+  if (
+    val.schemaName === "Mixed" ||
+    val.type?.schemaName === "Mixed" ||
+    (val.constructor === Object && _.isEmpty(val)) ||
+    (val.type?.constructor === Object && _.isEmpty(val.type))
+  ) {
     valType = "any";
   } else {
     const mongooseType = val.type === Map ? val.of : val.type;
@@ -323,6 +329,9 @@ const convertBaseTypeToTs = (key: string, val: any, isDocument: boolean) => {
       case mongoose.Types.ObjectId:
       case "ObjectId": // _id fields have type set to the string "ObjectId"
         valType = "mongoose.Types.ObjectId";
+        break;
+      case Object:
+        valType = "any";
         break;
       default:
         // this indicates to the parent func that this type is nested and we need to traverse one level deeper
@@ -468,7 +477,22 @@ export const parseSchema = ({
 
   const schemaTree = schema.tree;
 
-  const parseKey = (key: string, valOriginal: any): string => {
+  // parseSchema and getParseKeyFn call each other - both are exported consts
+  // eslint-disable-next-line @typescript-eslint/no-use-before-define
+  const parseKey = getParseKeyFn(isDocument, schema);
+
+  Object.keys(schemaTree).forEach((key: string) => {
+    const val = schemaTree[key];
+    template += parseKey(key, val);
+  });
+
+  template += footer;
+
+  return template;
+};
+
+export const getParseKeyFn = (isDocument: boolean, schema: any) => {
+  return (key: string, valOriginal: any): string => {
     // if the value is an object, we need to deepClone it to ensure changes to `val` aren't persisted in parent function
     let val = _.isPlainObject(valOriginal) ? _.cloneDeep(valOriginal) : valOriginal;
 
@@ -476,39 +500,48 @@ export const parseSchema = ({
     let isOptional = !val.required;
 
     let isArray = Array.isArray(val);
+    let isUntypedArray = false;
 
     // this means its a subdoc
     if (isArray) {
       val = val[0];
-      // if _isDefaultSetToUndefined is set, it means this is a subdoc array with `default: undefined`, indicating that mongoose will not automatically
-      // assign an empty array to the value. Therefore, isOptional = true. In other cases, isOptional is false since the field will be automatically initialized
-      // with an empty array
-      isOptional = val._isDefaultSetToUndefined ?? false;
+      if (val === undefined && val?.type === undefined) {
+        isUntypedArray = true;
+        isOptional = true;
+      } else {
+        // if _isDefaultSetToUndefined is set, it means this is a subdoc array with `default: undefined`, indicating that mongoose will not automatically
+        // assign an empty array to the value. Therefore, isOptional = true. In other cases, isOptional is false since the field will be automatically initialized
+        // with an empty array
+        isOptional = val._isDefaultSetToUndefined ?? false;
+      }
     } else if (Array.isArray(val.type)) {
       val.type = val.type[0];
       isArray = true;
 
-      /**
-       * Arrays can also take the following format.
-       * This is used when validation needs to be done on both the element itself and the full array.
-       * This format implies `required: true`.
-       *
-       * ```
-       * friends: {
-       *   type: [
-       *     {
-       *       type: Schema.Types.ObjectId,
-       *       ref: "User",
-       *       validate: [
-       *         function(userId: mongoose.Types.ObjectId) { return !this.friends.includes(userId); }
-       *       ]
-       *     }
-       *   ],
-       *   validate: [function(val) { return val.length <= 3; } ]
-       * }
-       * ```
-       */
-      if (val.type.type) {
+      if (val.type === undefined) {
+        isUntypedArray = true;
+        isOptional = true;
+      } else if (val.type.type) {
+        /**
+         * Arrays can also take the following format.
+         * This is used when validation needs to be done on both the element itself and the full array.
+         * This format implies `required: true`.
+         *
+         * ```
+         * friends: {
+         *   type: [
+         *     {
+         *       type: Schema.Types.ObjectId,
+         *       ref: "User",
+         *       validate: [
+         *         function(userId: mongoose.Types.ObjectId) { return !this.friends.includes(userId); }
+         *       ]
+         *     }
+         *   ],
+         *   validate: [function(val) { return val.length <= 3; } ]
+         * }
+         * ```
+         */
         if (val.type.ref) val.ref = val.type.ref;
         val.type = val.type.type;
         isOptional = false;
@@ -534,13 +567,16 @@ export const parseSchema = ({
     )
       val = { type: val };
 
-    const isMap = val.type === Map;
+    const isMap = val?.type === Map;
 
-    if (val._inferredInterfaceName) {
+    if (val === Array || val?.type === Array || isUntypedArray) {
+      // treat Array constructor and [] as an Array<Mixed>
+      isArray = true;
+      valType = "any";
+    } else if (val._inferredInterfaceName) {
       valType = val._inferredInterfaceName + (isDocument ? "Document" : "");
-    }
-    // check for virtual properties
-    else if (val.path && val.path && val.setters && val.getters) {
+    } else if (val.path && val.path && val.setters && val.getters) {
+      // check for virtual properties
       // skip id property
       if (key === "id") return "";
 
@@ -615,15 +651,6 @@ export const parseSchema = ({
 
     return makeLine({ key, val: valType, isOptional });
   };
-
-  Object.keys(schemaTree).forEach((key: string) => {
-    const val = schemaTree[key];
-    template += parseKey(key, val);
-  });
-
-  template += footer;
-
-  return template;
 };
 
 export const registerUserTs = (basePath: string): (() => void) | null => {

--- a/src/helpers/tests/parser.test.ts
+++ b/src/helpers/tests/parser.test.ts
@@ -88,3 +88,60 @@ describe("generateTypes", () => {
     expect(sourceFile.getFullText()).toBe(getExpectedInterfaceString(false));
   });
 });
+
+describe("getParseKeyFn", () => {
+  test("handles untyped Array equivalents as `any[]`", () => {
+    // see https://mongoosejs.com/docs/schematypes.html#arrays
+    const parseKey = parser.getParseKeyFn(false, {}, "foo");
+
+    {
+      const arrayResult = parseKey("test", { type: [mongoose.Schema.Types.Mixed] });
+      expect(arrayResult).toBe("test?: any[];\n");
+    }
+
+    {
+      const arrayResult = parseKey("test", []);
+      expect(arrayResult).toBe("test?: any[];\n");
+    }
+
+    {
+      const arrayResult = parseKey("test", { type: [] });
+      expect(arrayResult).toBe("test?: any[];\n");
+    }
+
+    {
+      const arrayResult = parseKey("test", { type: Array });
+      expect(arrayResult).toBe("test?: any[];\n");
+    }
+
+    {
+      const arrayResult = parseKey("test", { type: [{}] });
+      expect(arrayResult).toBe("test?: any[];\n");
+    }
+  });
+
+  test("handles Object equivalents as `any`", () => {
+    // see https://mongoosejs.com/docs/schematypes.html#mixed
+    const parseKey = parser.getParseKeyFn(false, {}, "foo");
+
+    {
+      const objectResult = parseKey("test", { type: mongoose.Schema.Types.Mixed });
+      expect(objectResult).toBe("test?: any;\n");
+    }
+
+    {
+      const objectResult = parseKey("test", { type: mongoose.Mixed });
+      expect(objectResult).toBe("test?: any;\n");
+    }
+
+    {
+      const objectResult = parseKey("test", { type: {} });
+      expect(objectResult).toBe("test?: any;\n");
+    }
+
+    {
+      const objectResult = parseKey("test", { type: Object });
+      expect(objectResult).toBe("test?: any;\n");
+    }
+  });
+});

--- a/src/helpers/tests/parser.test.ts
+++ b/src/helpers/tests/parser.test.ts
@@ -90,58 +90,45 @@ describe("generateTypes", () => {
 });
 
 describe("getParseKeyFn", () => {
-  test("handles untyped Array equivalents as `any[]`", () => {
+  test.only("handles untyped Array equivalents as `any[]`", () => {
     // see https://mongoosejs.com/docs/schematypes.html#arrays
-    const parseKey = parser.getParseKeyFn(false, {}, "foo");
+    const parseKey = parser.getParseKeyFn(false, {
+      test1a: { type: [mongoose.Schema.Types.Mixed], default: undefined }
+    });
 
-    {
-      const arrayResult = parseKey("test", { type: [mongoose.Schema.Types.Mixed] });
-      expect(arrayResult).toBe("test?: any[];\n");
-    }
+    expect(parseKey("test1a", { type: [mongoose.Schema.Types.Mixed] })).toBe("test1a: any[];\n");
+    expect(parseKey("test1b", [mongoose.Schema.Types.Mixed])).toBe("test1b: any[];\n");
 
-    {
-      const arrayResult = parseKey("test", []);
-      expect(arrayResult).toBe("test?: any[];\n");
-    }
+    expect(parseKey("test2a", { type: [] })).toBe("test2a: any[];\n");
+    expect(parseKey("test2b", [])).toBe("test2b: any[];\n");
 
-    {
-      const arrayResult = parseKey("test", { type: [] });
-      expect(arrayResult).toBe("test?: any[];\n");
-    }
+    expect(parseKey("test3a", { type: Array })).toBe("test3a: any[];\n");
+    expect(parseKey("test3b", Array)).toBe("test3b: any[];\n");
 
-    {
-      const arrayResult = parseKey("test", { type: Array });
-      expect(arrayResult).toBe("test?: any[];\n");
-    }
-
-    {
-      const arrayResult = parseKey("test", { type: [{}] });
-      expect(arrayResult).toBe("test?: any[];\n");
-    }
+    expect(parseKey("test4a", { type: [{}] })).toBe("test4a: any[];\n");
+    expect(parseKey("test4b", [{}])).toBe("test4b: any[];\n");
   });
 
   test("handles Object equivalents as `any`", () => {
     // see https://mongoosejs.com/docs/schematypes.html#mixed
-    const parseKey = parser.getParseKeyFn(false, {}, "foo");
+    const parseKey = parser.getParseKeyFn(false, {});
 
-    {
-      const objectResult = parseKey("test", { type: mongoose.Schema.Types.Mixed });
-      expect(objectResult).toBe("test?: any;\n");
-    }
+    expect(parseKey("test1a", { type: mongoose.Schema.Types.Mixed })).toBe("test1a?: any;\n");
+    expect(parseKey("test1b", mongoose.Schema.Types.Mixed)).toBe("test1b?: any;\n");
+    expect(parseKey("test1c", { type: mongoose.Schema.Types.Mixed, required: true })).toBe(
+      "test1c: any;\n"
+    );
 
-    {
-      const objectResult = parseKey("test", { type: mongoose.Mixed });
-      expect(objectResult).toBe("test?: any;\n");
-    }
+    expect(parseKey("test2a", { type: mongoose.Mixed })).toBe("test2a?: any;\n");
+    expect(parseKey("test2b", mongoose.Mixed)).toBe("test2b?: any;\n");
+    expect(parseKey("test2c", { type: mongoose.Mixed, required: true })).toBe("test2c: any;\n");
 
-    {
-      const objectResult = parseKey("test", { type: {} });
-      expect(objectResult).toBe("test?: any;\n");
-    }
+    expect(parseKey("test3a", { type: {} })).toBe("test3a?: any;\n");
+    expect(parseKey("test3b", {})).toBe("test3b?: any;\n");
+    expect(parseKey("test3c", { type: {}, required: true })).toBe("test3c: any;\n");
 
-    {
-      const objectResult = parseKey("test", { type: Object });
-      expect(objectResult).toBe("test?: any;\n");
-    }
+    expect(parseKey("test4a", { type: Object })).toBe("test4a?: any;\n");
+    expect(parseKey("test4b", Object)).toBe("test4b?: any;\n");
+    expect(parseKey("test4c", { type: Object, required: true })).toBe("test4c: any;\n");
   });
 });


### PR DESCRIPTION
Add support for many other ways of defining Object and Array types, documented here: [Array](https://mongoosejs.com/docs/schematypes.html#arrays) and [Object](https://mongoosejs.com/docs/schematypes.html#mixed)

- Explicit checks for Object and Array types, as well as the {} and [] literals. Also add support for {} and Mixed inside [] literals.
- Extract `parseKey` into `parseKeyFn` for reusable invocation and ability to unit test
- Add additional checks for `_isDefaultSetToUndefined`